### PR TITLE
Add basic Gradle build with JUnit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Zadanie-V-pis-obsahu-adres-ra
+
+## Running Tests
+
+Use Gradle to run the JUnit suite:
+
+```bash
+gradle test
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['.']
+            exclude 'test/**'
+        }
+    }
+    test {
+        java {
+            srcDirs = ['test']
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ShowFoldersDemo'

--- a/test/showfolders/ShowFoldersDemoTest.java
+++ b/test/showfolders/ShowFoldersDemoTest.java
@@ -1,0 +1,40 @@
+package showfolders;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class ShowFoldersDemoTest {
+
+    @Test
+    public void testShowMeDirectoriesPrintsPaths() throws Exception {
+        Path root = Files.createTempDirectory("demo");
+        Path sub = Files.createDirectory(root.resolve("sub"));
+        Path nested = Files.createDirectory(sub.resolve("nested"));
+        Path file1 = Files.createFile(sub.resolve("file1.txt"));
+        Path file2 = Files.createFile(nested.resolve("file2.txt"));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+        try {
+            File[] files = root.toFile().listFiles();
+            assertDoesNotThrow(() -> ShowFoldersDemo.showMeDirectories(files));
+        } finally {
+            System.setOut(original);
+        }
+
+        String output = out.toString();
+        assertTrue(output.contains("DIR:" + sub.toFile().getAbsolutePath()));
+        assertTrue(output.contains("DIR:" + nested.toFile().getAbsolutePath()));
+        assertTrue(output.contains(file1.toFile().getAbsolutePath()));
+        assertTrue(output.contains(file2.toFile().getAbsolutePath()));
+    }
+}


### PR DESCRIPTION
## Summary
- add Gradle build files and ignore build artifacts
- add `ShowFoldersDemoTest` with a temporary directory structure
- document running the tests in `README`

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684482dc60c8832e9b749e97afc1484e